### PR TITLE
Prepare for v2 with forked repo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 GitHub Action allowing for applying labels to issues and pull requests based on patterns found in the title or description.
 
-> NOTE: Due to limitations on GitHub Actions for [events that trigger workflows](https://help.github.com/en/actions/reference/events-that-trigger-workflows), labels from pull requests coming from forks are not currently supported.
+**NOTE** Thanks to the awesome efforts from the people at GitHub, `v2` and later support labeling from forked repositories via the [pull_request_target](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target) event.
 
 ## Usage
 
@@ -101,7 +101,7 @@ name: Community
 on: 
   issues:
     types: [opened, edited, milestoned]
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 jobs:
@@ -112,10 +112,13 @@ jobs:
     steps:
     - name: Check Labels
       id: labeler
-      uses: jimschubert/labeler-action@v1
+      uses: jimschubert/labeler-action@v2
       with:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 ```
+
+Notice that the PR event is [pull_request_target](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target) rather than `pull_request`. The difference is that `pull_request_target` is a newer event which runs in the context of the base repository, allowing access to the secrets necessary to label the pull request.
+If you use `pull_request`, the action will be able to label pull requests originating from the same repository (i.e. no forks!).
 
 ## License
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ go 1.14
 
 require (
 	github.com/google/go-github/v29 v29.0.3
-	github.com/jimschubert/labeler v0.0.1
+	github.com/jimschubert/labeler v0.0.3
 	github.com/sethvargo/go-githubactions v0.1.0
 	github.com/sirupsen/logrus v1.5.0
 )

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/google/go-github/v29 v29.0.3/go.mod h1:CHKiKKPHJ0REzfwc14QMklvtHwCveD
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
-github.com/jimschubert/labeler v0.0.1 h1:POSYV409zT/9CmlBMw2qBGPlj39qQ2somhoPt+iP5LE=
-github.com/jimschubert/labeler v0.0.1/go.mod h1:fEsqImOhJJS19cOxCv5L5KFKVYyr5jVxEe1456S3v/w=
+github.com/jimschubert/labeler v0.0.3 h1:77zKmB6gOHhNLRyjWqIPlqTzqMDuW/SJsJm4y1rEKJM=
+github.com/jimschubert/labeler v0.0.3/go.mod h1:fEsqImOhJJS19cOxCv5L5KFKVYyr5jVxEe1456S3v/w=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/main.go
+++ b/main.go
@@ -49,7 +49,7 @@ func main() {
 	}
 
 	re := regexp.MustCompile(`\r?\n\s*`)
-	event = re.ReplaceAll(event,[]byte(""))
+	event = re.ReplaceAll(event, []byte(""))
 
 	var id int
 	switch eventName {
@@ -61,7 +61,7 @@ func main() {
 		}
 
 		id = (*issue.Issue).GetNumber()
-	case "pull_request":
+	case "pull_request", "pull_request_target":
 		var pr *github.PullRequestEvent
 		err = json.Unmarshal(event, &pr)
 		if err != nil {


### PR DESCRIPTION
Adds support for the new [pull_request_target](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target) event, which allows for labeling pull requests which originate from forked repositories.