### PR TITLE
workflow: explicit permissions on pr.yml

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,6 +21,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
Potential fix for [https://github.com/jimschubert/labeler-action/security/code-scanning/2](https://github.com/jimschubert/labeler-action/security/code-scanning/2)

In general, the fix is to add an explicit `permissions` block setting the least privileges required, either at the workflow root (applies to all jobs without their own `permissions`) or within the specific job. Since this workflow delegates all work to a reusable workflow and no additional steps are defined here, the outer workflow itself likely does not require any write permissions; read-only should be sufficient.

The best minimal fix without changing functionality is to add a root-level `permissions` block after the `on:` section, setting `contents: read`. That constrains the `GITHUB_TOKEN` created for this workflow to read repository contents by default, while still allowing the reusable workflow to further refine permissions if necessary (job-level `permissions` in the called workflow override the inherited ones). Concretely, in `.github/workflows/pr.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block (lines 19–20) and the existing `concurrency` block (lines 22–24). No imports or additional methods are needed, as this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
